### PR TITLE
Added stride functionality in ConvBlock class

### DIFF
--- a/serotiny/networks/layers/convolution_block.py
+++ b/serotiny/networks/layers/convolution_block.py
@@ -24,6 +24,8 @@ def conv_block(
         number of output channels
     kernel_size: Sequence[int] (defaults to (3, 3, 3))
         dimensions of the convolutional kernel to be applied
+    stride: Sequence[int] (defaults to (1, 1, 1))
+        stride of the convolution
     padding:
         padding value for the convolution (defaults to 0)
     mode:
@@ -59,6 +61,7 @@ class ConvBlock(nn.Module):
         in_c: int,
         out_c: int,
         kernel_size: int = 3,
+        stride: int = 1,
         padding: int = 0,
         up_conv: bool = False,
         non_linearity: Optional[nn.Module] = None,
@@ -76,6 +79,8 @@ class ConvBlock(nn.Module):
             number of output channels
         kernel_size: Sequence[int] (defaults to (3, 3, 3))
             dimensions of the convolutional kernel to be applied
+        stride: Sequence[int] (defaults to (1, 1, 1))
+            stride of the convolution
         padding:
             padding value for the convolution (defaults to 0)
         mode:
@@ -88,6 +93,7 @@ class ConvBlock(nn.Module):
             in_c=in_c,
             out_c=out_c,
             kernel_size=kernel_size,
+            stride=stride,
             padding=padding,
             up_conv=up_conv,
             non_linearity=non_linearity,


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
N/A
- [x] Provide context of changes.
In a recent update of the dev branch, stride was enabled as a parameter in the convolution block so it could be called from the basiccnn function. However, in this implementation the stride argument was not added to the ConvBlock class. This bugfix aims to fix that. 
- [ ] Provide relevant tests for your feature or bug fix.
Not provided
- [x] Provide or update documentation for any feature added by your pull request.
New stride arguments are explained in the appropriate function definitions.