### PR TITLE
Improvement/base vae

### DIFF
--- a/serotiny/models/vae/base_vae.py
+++ b/serotiny/models/vae/base_vae.py
@@ -4,9 +4,14 @@ from omegaconf import DictConfig
 import torch
 import torch.nn as nn
 from torch.nn.modules.loss import _Loss as Loss
+from torch.optim.lr_scheduler import _LRScheduler as LRScheduler
 
 from serotiny.models.base_model import BaseModel
 from .priors import Prior, IsotropicGaussianPrior
+
+
+def _latent_compose_function(z_parts, **kwargs):
+    return z_parts
 
 
 class BaseVAE(BaseModel):
@@ -19,7 +24,7 @@ class BaseVAE(BaseModel):
         beta: float = 1.0,
         id_label: Optional[str] = None,
         optimizer: torch.optim.Optimizer = torch.optim.Adam,
-        loss_mask_label: Optional[str] = None,
+        lr_scheduler: Optional[LRScheduler] = None,
         reconstruction_loss: Loss = nn.MSELoss(reduction="none"),
         prior: Optional[Sequence[Prior]] = None,
         latent_compose_function=None,
@@ -27,7 +32,6 @@ class BaseVAE(BaseModel):
         **kwargs,
     ):
         """Instantiate a basic VAE model.
-
         Parameters
         ----------
         encoder: nn.Module
@@ -35,9 +39,7 @@ class BaseVAE(BaseModel):
         decoder: nn.Module
             Decoder network
         x_label: Optional[str] = None
-
         id_label: Optional[str] = None
-
         optimizer: torch.optim.Optimizer
             Optimizer to use
         beta: float = 1.0
@@ -58,7 +60,10 @@ class BaseVAE(BaseModel):
             encoder = {x_label: encoder}
         self.encoder = nn.ModuleDict(encoder)
 
-        self.decoder = decoder
+        if not isinstance(decoder, (dict, DictConfig)):
+            assert x_label is not None
+            decoder = {x_label: decoder}
+        self.decoder = nn.ModuleDict(decoder)
 
         self.beta = beta
         self.latent_dim = latent_dim
@@ -71,34 +76,48 @@ class BaseVAE(BaseModel):
             prior = {x_label: prior}
 
         self.prior = nn.ModuleDict(prior)
+
+        if latent_compose_function is None:
+            latent_compose_function = _latent_compose_function
         self.latent_compose_function = latent_compose_function
 
-    def calculate_elbo(self, x, x_hat, z, mask=None):
-        rcl_per_input_dimension = self.reconstruction_loss(x_hat, x)
+    def calculate_rcl(self, x, x_hat, key):
+        rcl_per_input_dimension = self.reconstruction_loss[key](x[key], x_hat[key])
+        return rcl_per_input_dimension
 
-        if mask is not None:
-            rcl_per_input_dimension = rcl_per_input_dimension * mask
+    def calculate_elbo(self, x, x_hat, z):
 
-        rcl = (
-            rcl_per_input_dimension
-            # flatten
-            .view(rcl_per_input_dimension.shape[0], -1)
-            # and sum across each batch element's dimensions
-            .sum(dim=1)
-        )
+        rcl_per_input_dimension = {}
+        rcl_reduced = {}
+        for key in x_hat.keys():
+            rcl_per_input_dimension[key] = self.calculate_rcl(x, x_hat, key)
+            if len(rcl_per_input_dimension[key].shape) > 0:
+                rcl = (
+                    rcl_per_input_dimension[key]
+                    # flatten
+                    .view(rcl_per_input_dimension[key].shape[0], -1)
+                    # and sum across each batch element's dimensions
+                    .sum(dim=1)
+                )
 
-        rcl = rcl.mean()
+                rcl_reduced[key] = rcl.mean()
+            else:
+                rcl_reduced[key] = rcl_per_input_dimension[key]
 
         kld_per_part = {
-            part: self.prior[part](z_part, mode="kl") for part, z_part in z.items()
+            part: self.prior[part](z_part, mode="kl", reduction="none")
+            for part, z_part in z.items()
         }
 
-        kld = torch.sum(kld_per_part.values(), dim=1).mean()
+        kld_per_part_summed = {
+            part: kl.sum(dim=-1).mean() for part, kl in kld_per_part.items()
+        }
 
+        total_kld = sum(kld_per_part_summed.values())
         return (
-            rcl + self.beta * kld,
-            rcl,
-            kld,
+            sum(rcl_reduced.values()) + self.beta * total_kld,
+            rcl_reduced,
+            total_kld,
             kld_per_part,
         )
 
@@ -109,57 +128,63 @@ class BaseVAE(BaseModel):
         }
 
     def encode(self, batch):
-        return {part: encoder(batch[part]) for part, encoder in self.encoder.items()}
+        return {
+            part: encoder(batch[part].float()) for part, encoder in self.encoder.items()
+        }
 
     def decode(self, z_parts):
-        if self.latent_compose_function is not None:
-            z = self.latent_compose_function(z_parts)
-        else:
-            z = torch.cat(z_parts.values(), dim=1)
-        return self.decoder(z)
+        z = self.latent_compose_function(z_parts)
 
-    def forward(self, batch, decode=False, compute_loss=False):
+        return (
+            {part: decoder(z[part].float()) for part, decoder in self.decoder.items()},
+            z,
+        )
+
+    def forward(self, batch, decode=False, compute_loss=False, **kwargs):
+
         z_parts_params = self.encode(batch)
 
-        if not decode:
-            return z_parts_params
-
         z_parts = self.sample_z(z_parts_params)
-        x_hat = self.decode(z_parts)
+
+        x_hat, z_composed = self.decode(z_parts)
+
+        if not decode:
+            return z_parts_params, z_composed
 
         if not compute_loss:
-            return x_hat, z_parts, z_parts_params
+            return x_hat, z_parts, z_parts_params, z_composed
 
-        mask = batch.get(self.hparams.get("loss_mask_label"))
-
-        (loss, reconstruction_loss, kld_loss, kld_per_part,) = self.calculate_elbo(
-            batch[self.hparams.x_label], x_hat, z_parts_params, mask=mask
-        )
+        (
+            loss,
+            reconstruction_loss,
+            kld_loss,
+            kld_per_part,
+        ) = self.calculate_elbo(batch, x_hat, z_parts_params)
 
         return (
             x_hat,
             z_parts,
             z_parts_params,
+            z_composed,
             loss,
             reconstruction_loss,
             kld_loss,
             kld_per_part,
         )
 
-    def log_metrics(self, stage, reconstruction_loss, kld_loss, loss, logger):
-        on_step = stage == "train"
+    def log_metrics(self, stage, results, logger, batch_size):
+        on_step = (stage == "val") | (stage == "train")
 
-        self.log(
-            f"{stage} reconstruction loss",
-            reconstruction_loss,
-            logger=logger,
-            on_step=on_step,
-            on_epoch=True,
-        )
-        self.log(
-            f"{stage} kld loss", kld_loss, logger=logger, on_step=on_step, on_epoch=True
-        )
-        self.log(f"{stage}_loss", loss, logger=logger, on_step=on_step, on_epoch=True)
+        for key, value in results.items():
+            if (len(value.shape) == 0) | (len(value.shape) == 1):
+                self.log(
+                    f"{stage} {key}",
+                    value,
+                    logger=logger,
+                    on_step=on_step,
+                    on_epoch=True,
+                    batch_size=batch_size,
+                )
 
     def make_results_dict(
         self,
@@ -171,16 +196,30 @@ class BaseVAE(BaseModel):
         kld_per_part,
         z_parts,
         z_parts_params,
+        z_composed,
         x_hat,
     ):
         results = {
             "loss": loss,
             f"{stage}_loss": loss.detach().cpu(),  # for epoch end logging purposes
-            "reconstruction_loss": reconstruction_loss.detach().cpu(),
             "kld_loss": kld_loss.detach().cpu(),
         }
 
-        for part, z_part in z_parts.keys():
+        for part, z_comp_part in z_composed.items():
+            results.update(
+                {
+                    f"z_composed/{part}": z_comp_part.detach().cpu(),
+                }
+            )
+
+        for part, recon_part in reconstruction_loss.items():
+            results.update(
+                {
+                    f"reconstruction_loss/{part}": recon_part.detach().cpu(),
+                }
+            )
+
+        for part, z_part in z_parts.items():
             results.update(
                 {
                     f"z_parts/{part}": z_part.detach().cpu(),
@@ -188,15 +227,6 @@ class BaseVAE(BaseModel):
                     f"kld/{part}": kld_per_part[part].detach().float().cpu(),
                 }
             )
-
-        if stage == "test":
-            results.update(
-                {
-                    "x_hat": x_hat.detach().cpu(),
-                }
-            )
-            for k, v in batch.items():
-                results[k] = v.detach.cpu()
 
         if self.hparams.id_label is not None:
             if self.hparams.id_label in batch:
@@ -210,15 +240,14 @@ class BaseVAE(BaseModel):
             x_hat,
             z_parts,
             z_parts_params,
+            z_composed,
             loss,
             reconstruction_loss,
             kld_loss,
             kld_per_part,
         ) = self.forward(batch, decode=True, compute_loss=True)
 
-        self.log_metrics(stage, reconstruction_loss, kld_loss, loss, logger)
-
-        return self.make_results_dict(
+        results = self.make_results_dict(
             stage,
             batch,
             loss,
@@ -227,5 +256,10 @@ class BaseVAE(BaseModel):
             kld_per_part,
             z_parts,
             z_parts_params,
+            z_composed,
             x_hat,
         )
+
+        self.log_metrics(stage, results, logger, batch[self.hparams.x_label].shape[0])
+
+        return results


### PR DESCRIPTION
BaseVAE modifications for use cases where there are multiple inputs (e.g. transcriptomics and images) or single inputs. Multiple inputs mean there will be multiple reconstruction losses per input. To be used like so

```
_aux_:
  _: &input1 "image"
  _: &id "cell_id"
  _: &latent_dim 10
  _: &twice_latent_dim 20
  _: &in_channels 1
  _: &hidden_channels 4
  _: &kernel_size 3
  _: &stride 1
  _: &beta 1
  _: &input_dims [132, 240, 378]
  _: &conv_block
    _target_: torch.nn.Sequential
    _args_:
      - _target_: torch.nn.LazyConv3d
        out_channels: *hidden_channels
        kernel_size: *kernel_size
        stride: 1
      - _target_: torch.nn.LeakyReLU
      - _target_: torch.nn.LazyBatchNorm3d
  _: &encoder_conv
    _target_: torch.nn.Sequential
    _args_:
      - *conv_block
      - *conv_block
      - *conv_block
      
_target_: serotiny.models.vae.BaseVAE
encoder:
    *input1: 
      _target_: torch.nn.Sequential
      _args_:
        - *encoder_conv
        - _target_: serotiny.networks.layers.Flatten
        - _target_: torch.nn.LazyLinear
          out_features: *twice_latent_dim
decoder:
    *input1:
      _target_: serotiny.networks.vae.ImageDecoder
      encoder: *encoder_conv
      input_dims: *input_dims
      in_channels: *in_channels
      latent_dim: *latent_dim
      
latent_dim: *latent_dim
x_label: *input1
beta: *beta
id_label: *id
optimizer: 
  _partial_: True
  _target_: torch.optim.Adam
  lr: 1e-3
reconstruction_loss:
  *input1: 
    _target_: torch.nn.MSELoss
    reduction: "mean"
prior:
  *input1: 
    _target_: serotiny.models.vae.priors.IsotropicGaussianPrior
    dimensionality: *latent_dim
```