### PR TITLE
fix search for -cd in argv

### DIFF
--- a/hydra_plugins/serotiny_search_path/search_path.py
+++ b/hydra_plugins/serotiny_search_path/search_path.py
@@ -13,7 +13,7 @@ class SerotinySearchPath(SearchPathPlugin):
             if "-sc" in sys.argv and any(["install" in _arg for _arg in sys.argv]):
                 pass
             elif not any(
-                [("config-dir" in _arg or "-cd" in _arg) for _arg in sys.argv]
+                [("config-dir" in _arg or _arg.startswith("-cd")) for _arg in sys.argv]
             ):
                 # look for a .serotiny file in the current directory. if it exists,
                 # it means we're in a serotiny project. the .serotiny file will contain


### PR DESCRIPTION
Fixes a bug with the search path plugin (which lets hydra search in the config dirs of serotiny projects).

Currently the plugin checks whether any atom in argv contains `-cd`, which is a hydra param name for "config dir", and stops if it find one, because this means the user is explicitly specifying a config dir. However this test also passes if any atom contains the string `-cd` rather than simply beginning with `-cd`, which was causing problems.
