### PR TITLE
add new mlflow autolog param

### DIFF
--- a/serotiny/ml_ops/mlflow_utils.py
+++ b/serotiny/ml_ops/mlflow_utils.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 @autologging_integration("pytorch")
 def patched_autolog(
     log_every_n_epoch=1,
+    log_every_n_step=50,
     log_models=False,  # we handle this
     disable=False,
     exclusive=False,


### PR DESCRIPTION
Newer MLFlow versions need an additional `log_every_n_step` parameter to be set in order to log intra-epoch values. Default is `None` which means only logging at the end of an epoch.