### PR TITLE
make sure we log only scalars

### DIFF
--- a/serotiny/models/vae/base_vae.py
+++ b/serotiny/models/vae/base_vae.py
@@ -176,10 +176,10 @@ class BaseVAE(BaseModel):
         on_step = (stage == "val") | (stage == "train")
 
         for key, value in results.items():
-            if (len(value.shape) == 0) | (len(value.shape) == 1):
+            if (len(value.shape) == 0) | (len(value.shape) == value.shape[0] == 1):
                 self.log(
                     f"{stage} {key}",
-                    value,
+                    value.squeeze(),
                     logger=logger,
                     on_step=on_step,
                     on_epoch=True,


### PR DESCRIPTION
We were checking for `len(value.shape) == 1` which includes 1d vectors. Now checking that the length of the vector is 1 and also squeezing it before logging
