### PR TITLE
add default dimensionality to prior abstract class

### DIFF
--- a/serotiny/models/vae/priors/abstract_prior.py
+++ b/serotiny/models/vae/priors/abstract_prior.py
@@ -4,7 +4,7 @@ _full_slice = slice(None, None, None)
 
 
 class Prior(nn.Module):
-    def __init__(self, dimensionality: int, **kwargs):
+    def __init__(self, dimensionality: int = -1, **kwargs):
         super().__init__()
         self.dimensionality = dimensionality
 


### PR DESCRIPTION
Just adding a default `dimensionality` argument to the `AbstractPrior` class because some of its subclasses don't take it as a parameter (e.g. `IsotropicGaussianPrior`) because it isn't needed
