### PR TITLE
add mlflow logger with checkpointing ability

### DIFF
--- a/serotiny/loggers/__init__.py
+++ b/serotiny/loggers/__init__.py
@@ -1,0 +1,1 @@
+from .mlflow import MLFlowLogger

--- a/serotiny/loggers/mlflow.py
+++ b/serotiny/loggers/mlflow.py
@@ -1,0 +1,57 @@
+import os
+from pathlib import Path
+
+from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
+from pytorch_lightning.callbacks import ModelCheckpoint
+from pytorch_lightning.loggers import MLFlowLogger as _MLFlowLogger
+
+LOCAL_FILE_URI_PREFIX = "file:"
+
+
+class MLFlowLogger(_MLFlowLogger):
+    def after_save_checkpoint(self, ckpt_callback: ModelCheckpoint) -> None:
+        """Called after model checkpoint callback saves a new checkpoint."""
+
+        monitor = ckpt_callback.monitor
+        if monitor is not None:
+            artifact_path = f"checkpoints/{monitor}"
+            existing_ckpts = set(
+                _.split("/")[-1]
+                for _ in self.experiment.list_artifacts(self.run_id, path=artifact_path)
+            )
+
+            top_k_ckpts = set(
+                _.split("/")[-1] for _ in ckpt_callback.best_k_models.keys()
+            )
+
+            to_delete = existing_ckpts - top_k_ckpts
+            to_upload = top_k_ckpts - existing_ckpts
+
+            run = self.experiment.get_run(self.run_id)
+            repository = get_artifact_repository(run.info.artifact_uri)
+            for ckpt in to_delete:
+                repository.delete_artifact(Path(ckpt).name)
+
+            for ckpt in to_upload:
+                self.experiment.log_artifact(
+                    self.run_id, local_path=ckpt, artifact_path=artifact_path
+                )
+        else:
+            filepath = ckpt_callback.best_model_path
+            artifact_path = "checkpoints"
+
+            # mimic ModelCheckpoint's behavior: if `self.save_top_k == 1` only
+            # keep the latest checkpoint, otherwise keep all of them.
+            if self.save_top_k == 1:
+                latest_path = Path(filepath).with_name("latest.ckpt")
+                os.link(filepath, latest_path)
+
+                self.experiment.log_artifact(
+                    self.run_id, local_path=latest_path, artifact_path=artifact_path
+                )
+
+                os.unlink(latest_path)
+            else:
+                self.experiment.log_artifact(
+                    self.run_id, local_path=filepath, artifact_path=artifact_path
+                )

--- a/serotiny/loggers/mlflow.py
+++ b/serotiny/loggers/mlflow.py
@@ -43,14 +43,14 @@ class MLFlowLogger(_MLFlowLogger):
             # mimic ModelCheckpoint's behavior: if `self.save_top_k == 1` only
             # keep the latest checkpoint, otherwise keep all of them.
             if self.save_top_k == 1:
-                latest_path = Path(filepath).with_name("latest.ckpt")
-                os.link(filepath, latest_path)
+                last_path = Path(filepath).with_name("last.ckpt")
+                os.link(filepath, last_path)
 
                 self.experiment.log_artifact(
-                    self.run_id, local_path=latest_path, artifact_path=artifact_path
+                    self.run_id, local_path=last_path, artifact_path=artifact_path
                 )
 
-                os.unlink(latest_path)
+                os.unlink(last_path)
             else:
                 self.experiment.log_artifact(
                     self.run_id, local_path=filepath, artifact_path=artifact_path

--- a/serotiny/models/utils/__init__.py
+++ b/serotiny/models/utils/__init__.py
@@ -1,0 +1,1 @@
+from .mlflow import load_model_from_checkpoint

--- a/serotiny/models/utils/mlflow.py
+++ b/serotiny/models/utils/mlflow.py
@@ -1,0 +1,44 @@
+import logging
+import tempfile
+
+import mlflow
+from hydra.utils import instantiate
+from hydra._internal.utils import _locate
+from mlflow.tracking import MlflowClient
+from omegaconf import OmegaConf
+
+logger = logging.getLogger(__name__)
+
+
+def get_config(tracking_uri, run_id, tmp_dir, mode="train"):
+    artifact_path = f"config/{mode}.yaml"
+    client = mlflow.tracking.MlflowClient(tracking_uri)
+    config = client.download_artifacts(
+        run_id=run_id,
+        path=artifact_path,
+        dst_path=tmp_dir,
+    )
+
+    config = OmegaConf.load(config)
+    config = OmegaConf.to_container(config, resolve=True)
+
+    return config
+
+
+def load_model_from_checkpoint(
+    tracking_uri, run_id, strict=True, path="checkpoints/last.ckpt"
+):
+    mlflow.set_tracking_uri(tracking_uri)
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        client = MlflowClient(tracking_uri=tracking_uri)
+        ckpt_path = client.download_artifacts(
+            run_id=run_id, path=path, dst_path=tmp_dir
+        )
+
+        config = get_config(tracking_uri, run_id, tmp_dir, mode="train")
+
+        model_conf = config["model"]
+        model_class = model_conf.pop("_target_")
+        model_conf = instantiate(model_conf)
+        model_class = _locate(model_class)
+        return model_class.load_from_checkpoint(ckpt_path, **model_conf, strict=strict)

--- a/serotiny/tests/test_mlflow_logger.py
+++ b/serotiny/tests/test_mlflow_logger.py
@@ -1,0 +1,88 @@
+import os
+from unittest import mock
+
+import pytest
+
+import torch
+from pytorch_lightning import Trainer
+from pytorch_lightning.demos.boring_classes import BoringModel
+from pytorch_lightning.callbacks import ModelCheckpoint
+
+from serotiny.loggers import MLFlowLogger
+
+
+@mock.patch("pytorch_lightning.loggers.mlflow._MLFLOW_AVAILABLE", return_value=True)
+@pytest.mark.parametrize("monitor", [True, False])
+def test_mlflow_log_model(_, tmpdir, monitor):
+    """Test that the logger creates the folders and files in the right
+    place."""
+
+    max_epochs = 10
+    limit_train_batches = 3
+    limit_val_batches = 3
+    monitor_key = "val_log"
+
+    class CustomBoringModel(BoringModel):
+        def __init__(self):
+            super().__init__()
+            self.train_log_epochs = torch.randn(max_epochs, limit_train_batches)
+            self.val_logs = torch.randn(max_epochs, limit_val_batches)
+            self.scores = []
+
+        def training_step(self, batch, batch_idx):
+            log_value = self.train_log_epochs[self.current_epoch, batch_idx]
+            self.log("train_log", log_value, on_epoch=True)
+            return super().training_step(batch, batch_idx)
+
+        def validation_step(self, batch, batch_idx):
+            log_value = self.val_logs[self.current_epoch, batch_idx]
+            self.log(monitor_key, log_value)
+            return super().validation_step(batch, batch_idx)
+
+        def on_train_epoch_end(self):
+            if "train" in monitor_key:
+                self.scores.append(self.trainer.logged_metrics[monitor_key])
+
+        def on_validation_epoch_end(self):
+            if not self.trainer.sanity_checking and "val" in monitor_key:
+                self.scores.append(self.trainer.logged_metrics[monitor_key])
+
+    model = CustomBoringModel()
+
+    mlflow_root = os.path.join(tmpdir, "mlflow/")
+    local_ckpt_root = os.path.join(tmpdir, "local_ckpt")
+
+    logger = MLFlowLogger("test", save_dir=mlflow_root)
+
+    if monitor:
+        checkpoint_callback = ModelCheckpoint(
+            dirpath=local_ckpt_root, save_top_k=2, monitor=monitor_key
+        )
+    else:
+        checkpoint_callback = ModelCheckpoint(
+            dirpath=local_ckpt_root, save_top_k=1, monitor=None
+        )
+
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        logger=logger,
+        callbacks=[checkpoint_callback],
+        max_epochs=max_epochs,
+        limit_train_batches=limit_train_batches,
+        limit_val_batches=limit_val_batches,
+    )
+    trainer.fit(model)
+
+    if monitor:
+        ckpt_folder = os.path.join(
+            mlflow_root,
+            f"1/{logger.run_id}/artifacts/checkpoints/{monitor_key}",
+        )
+
+        assert len(os.listdir(ckpt_folder)) == 2
+    else:
+        ckpt_folder = os.path.join(
+            mlflow_root, f"1/{logger.run_id}/artifacts/checkpoints"
+        )
+        assert len(os.listdir(ckpt_folder)) == 1
+        assert os.path.isfile(os.path.join(ckpt_folder, "last.ckpt"))


### PR DESCRIPTION
Addressing #133 . Simplifying the interaction with MLFlow by leveraging Lightning's `MLFlowLogger` and adding checkpoint functionality to it. It works by tapping into the `after_save_checkpoint` hook and uploading saved checkpoints as artifacts to MLFlow there. It also mimics Lightning's `ModelCheckpoint` callback functionality of (optionally) only keeping the top k checkpoints based on some monitored metric.

**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [x] Link to any relevant issue in the PR description.
- [x] Provide context of changes.
- [x] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

