### PR TITLE
Feature/mixed 3d and 2d cropping

### DIFF
--- a/serotiny/image/transforms/multiscale_cropper.py
+++ b/serotiny/image/transforms/multiscale_cropper.py
@@ -4,6 +4,16 @@ from typing import Sequence, Callable, Dict
 
 
 def _apply_slice(data, slicee):
+    """
+    If the slice is generated for 3d images, but the passed data is a 2d image
+    (e.g. if we are predicting a 3d image and a 2d image), this will apply the CXY portions
+    of the slice.
+
+    Parameters
+    ----------
+    data: image with shape C[Z]YX
+    slice: slice object with length 3 (generated for 2d images) or 4 (generated for 3d images)
+    """
     # pop z dimension to take corresponding 2d slice if 2d image is passed
     if len(data.shape) == len(slicee) - 1:
         slicee.pop(1)
@@ -49,7 +59,7 @@ class RandomMultiScaleCropd(RandomizableTransform):
         selection_fn: Callable=None
             Function that takes in an image and returns True or False. Used to
             decide whether a sampled image should be kept or discarded.
-        nax_attempts: int=100
+        max_attempts: int=100
             max attempts to try sampling patches from an image before quitting
         """
         super().__init__()


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!

Use case: 
multitask setting where one task output is a 3d image and a separate task output is a 2d image. e.g. predicting a 3d segmentation of interphase nuclei and 2d segmentation of mitotic nuclei. 

Changes: 
-  crop 2d targets to the same xy coordinates as the 3d slice
-  typo fixes 