### PR TITLE
fix subsampling when not specified in config

### DIFF
--- a/serotiny/datamodules/dataframe/dataframe_datamodule.py
+++ b/serotiny/datamodules/dataframe/dataframe_datamodule.py
@@ -133,7 +133,7 @@ class DataframeDatamodule(pl.LightningDataModule):
     def get_dataset(self, split):
         sample_size = self.subsample.get(split, -1)
 
-        if self.subsample[split] == -1:
+        if sample_size == -1:
             return self.datasets[split]
 
         sample = self.rng.integers(len(self.datasets[split]), size=sample_size).tolist()


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!

Previous code failed when subsample wasn't provided in config. This defaults to -1 (all images) when subsample not provided. 
