### PR TITLE
fix cropping with patch size = image size

### DIFF
--- a/serotiny/image/transforms/multiscale_cropper.py
+++ b/serotiny/image/transforms/multiscale_cropper.py
@@ -88,7 +88,7 @@ class RandomMultiScaleCropd(RandomizableTransform):
         max_shape = np.asarray(
             image_dict[self.scale_dict[1][0]].shape[-self.spatial_dims :]
         )
-        max_start_indices = max_shape - self.roi_size
+        max_start_indices = max_shape - self.roi_size + 1
         start_indices = self.R.randint(max_start_indices)
         scaled_start_indices = {
             s: (start_indices // s).astype(int) for s in self.scale_dict.keys()


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!

Randint doesn't included upper bound, so if any  image_dimension == patch_dimension, cropping will fail even if a valid crop can be taken. Adding 1 to the max start indices fixes this. 
