### PR TITLE
use correct python version to match precommit's (python3.8)

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: '3.10'
+          python-version: '3.8'
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
"test-and-lint" action was failing because pre-commit was being run within a context with the wrong python version. this fixes it.