### PR TITLE
copy slice object before removing z dimension

### DIFF
--- a/serotiny/image/transforms/multiscale_cropper.py
+++ b/serotiny/image/transforms/multiscale_cropper.py
@@ -18,7 +18,8 @@ def _apply_slice(data, slicee):
     """
     # pop z dimension to take corresponding 2d slice if 2d image is passed
     if len(data.shape) == len(slicee) - 1:
-        slicee.pop(1)
+        # copy to avoid changing slicee object
+        return data[slicee.copy().pop(1)]
     return data[slicee]
 
 


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!

Previous code modified the slice object in place, so if a 3d crops were created after a 2d crop, the 3d crop would crop in CZY dimensions instead of CZYX. copying the slice before popping fixes this.
