### PR TITLE
add key interpolation resolver

### DIFF
--- a/serotiny/utils/__init__.py
+++ b/serotiny/utils/__init__.py
@@ -1,0 +1,3 @@
+from .config import (
+    kv_to_dict
+)

--- a/serotiny/utils/config.py
+++ b/serotiny/utils/config.py
@@ -1,0 +1,23 @@
+from omegaconf import DictConfig, ListConfig, OmegaConf
+
+
+def kv_to_dict(kv: ListConfig) -> DictConfig:
+    """
+    Parameters
+    ----------
+    kv: ListConfig
+        ListConfig where every item is a nested list of the form [interpolated key, value]
+    Returns
+    -------
+    DictConfig of input
+    """
+    if isinstance(kv, ListConfig):
+        ret = {}
+        for item in kv:
+            assert (
+                len(item) == 2
+            ), f"Expected ListConfig item to have len 2, got {len(item)}"
+            ret[item[0]] = OmegaConf.to_container(item[1], resolve=True)
+    else:
+        raise TypeError("Config resolved with kv_to_dict must be ListConfig")
+    return OmegaConf.create(ret)


### PR DESCRIPTION
**Pull request recommendations:**
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [x] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.

Thanks for contributing!
This resolver lets us interpolate keys , e.g.
```
postprocessing: 
  input: ${kv_to_dict:${_aux._input_postprocessing}}
  prediction: ${kv_to_dict:${_aux._prediction_postprocessing}}

_aux:
  _input_postprocessing:
    - - ${source_col}
      - _target_: aics_im2im.utils.postprocessing.rescale
        _partial_: True
    - - ${target_col}
      - _target_: aics_im2im.utils.postprocessing.rescale
        _partial_: True
  _prediction_postprocessing:
    - - ${target_col}
      - _target_: aics_im2im.utils.postprocessing.rescale
        _partial_: True

```
resolves to 
```
postprocessing:
   input:
     raw:
       _target_: aics_im2im.utils.postprocessing.rescale
       _partial_: true
     seg:
       _target_: aics_im2im.utils.postprocessing.rescale
       _partial_: true
   prediction:
     seg:
       _target_: aics_im2im.utils.postprocessing.rescale
       _partial_: true

```