### PR TITLE
feature/accept-strings-or-ints-as-channels-in-omezarrreader

### DIFF
--- a/serotiny/image/io/ome_zarr_reader.py
+++ b/serotiny/image/io/ome_zarr_reader.py
@@ -43,7 +43,13 @@ class OmeZarrReader(ImageReader):
         for img_obj in ensure_tuple(img):
             data = img_obj.data[self.level].compute()[0]
             if self.channels:
-                data = data[self.channels]
+                _metadata_channels = img_obj.metadata["name"]
+                _channels = [
+                    ch if isinstance(ch, int) else _metadata_channels.index(ch)
+                    for ch in self.channels
+                ]
+                data = data[_channels]
+
             img_array.append(data)
 
         return _stack_images(img_array, {}), {}

--- a/serotiny/utils/__init__.py
+++ b/serotiny/utils/__init__.py
@@ -1,3 +1,1 @@
-from .config import (
-    kv_to_dict
-)
+from .config import kv_to_dict

--- a/serotiny/utils/config.py
+++ b/serotiny/utils/config.py
@@ -6,7 +6,9 @@ def kv_to_dict(kv: ListConfig) -> DictConfig:
     Parameters
     ----------
     kv: ListConfig
-        ListConfig where every item is a nested list of the form [interpolated key, value]
+        ListConfig where every item is a nested list of the
+        form [interpolated key, value]
+
     Returns
     -------
     DictConfig of input


### PR DESCRIPTION
`OmeZarrReader` can interpret `channels` as either integer channel indices, or string channel labels - in which case it leverages the OME metadata to infer the channel order.

EDIT: also linted `serotiny/utils/__init__.py` because it was triggering the linter.

---
- [x] Name your pull request _your-development-type/short-description_. Ex: _feature/read-tiff-files_
- [ ] Link to any relevant issue in the PR description. Ex: _Resolves [gh-12], adds tiff file format support_
- [ ] Provide context of changes.
- [ ] Provide relevant tests for your feature or bug fix.
- [ ] Provide or update documentation for any feature added by your pull request.